### PR TITLE
Grammar bug

### DIFF
--- a/build/iscroll.js
+++ b/build/iscroll.js
@@ -18,7 +18,7 @@ var utils = (function () {
 			l = vendors.length;
 
 		for ( ; i < l; i++ ) {
-			transform = vendors[i] + 'ransform';
+			transform = vendors[i] + 'transform';
 			if ( transform in _elementStyle ) return vendors[i].substr(0, vendors[i].length-1);
 		}
 


### PR DESCRIPTION
looping through the vendors, in the beginning, there's a typo 'ransform' suppose to be transform. This fixes issue where I couldnt scroll past some sections